### PR TITLE
allow use of multiple editors and fix initial button state

### DIFF
--- a/chinese/edit.py
+++ b/chinese/edit.py
@@ -17,8 +17,8 @@
 # You should have received a copy of the GNU General Public License along with
 # Chinese Support 3.  If not, see <https://www.gnu.org/licenses/>.
 
-import anki.notes
-import aqt.editor
+import anki
+import aqt
 from anki.hooks import addHook
 from aqt import gui_hooks, mw
 


### PR DESCRIPTION
This PR fixes two things currently broken with the editor integration:

### update editor focus lost hook to report when note was changed 

Previously when a note was modified, the plugin would manually reload the note in the editor. This commit modifies things to take advantage of the built in hook infrastructure to auto-reload the note.

As a bonus, this fixes a bug caused assuming only one editor would be open at a time and closes #27.

### ensure button status is correctly set when editor opens 

The `loadNote` / `editor_did_load_note` hooks run as soon as a note is loaded, but not necesarrily after the ui component has been mounted to the DOM. By adding a delay of 50 ms before setting button state, this should help alleviate the race condition.