### PR TITLE
fix bug where `b` and `r` were trimmed from the end of definitions

### DIFF
--- a/chinese/behavior.py
+++ b/chinese/behavior.py
@@ -81,7 +81,7 @@ def fill_def(hanzi, note, lang):
 
     definition = ''
     if get_first(config['fields'][field], note) == '':
-        definition = translate(hanzi, lang).rstrip('<br>\n')
+        definition = translate(hanzi, lang).removesuffix('\n<br>')
         if definition:
             definition += classifier + alt
             set_all(config['fields'][field], note, to=definition)

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -24,6 +24,7 @@ from chinese.behavior import (
     fill_all_rubies,
     fill_classifier,
     fill_color,
+    fill_def,
     fill_simp,
     fill_sound,
     fill_trad,
@@ -431,6 +432,13 @@ class FillColor(Base):
             note['Color Hanzi'],
             '<span class="tone5">Brian</span><span class="tone5">的</span>',
         )
+
+
+class FillDef(Base):
+    def test_trailing_new_line_removed(self):
+        note = {"English": ""}
+        assert fill_def("浴缸", note, "en")
+        self.assertEqual(note["English"], " \tbathtub")
 
 
 class FillAllDefs(Base):


### PR DESCRIPTION
`rstrip` removes the set of characters provided from the end of the string, the desired behaviour is instead that which is provided by `removesuffix`.

Closes #29.