### PR TITLE
Added colorHanziTaiwan and  colorTraditionalTaiwan fields

### DIFF
--- a/chinese/behavior.py
+++ b/chinese/behavior.py
@@ -225,8 +225,8 @@ def fill_color(hanzi, note):
     #traditional color
     tradHanzi = get_first(config['fields']['traditional'], note)
     if tradHanzi:
-        tradHanzi = split_hanzi(cleanup(tradHanzi), grouped=False)
-        colorized = colorize_fuse(tradHanzi, trans)
+        tradHanziSplit = split_hanzi(cleanup(tradHanzi), grouped=False)
+        colorized = colorize_fuse(tradHanziSplit, trans)
         set_all(config['fields']['colorTraditional'], note, to=colorized)
 
     #cantonese color
@@ -236,6 +236,23 @@ def fill_color(hanzi, note):
         cantoTrans = sanitize_transcript(cantoField, "jyutping", grouped=False)
         colorized = colorize_fuse(hanzi, cantoTrans)
         set_all(config['fields']['colorCantonese'], note, to=colorized)
+
+    # ### Taiwan color ###
+    # Check if config.json already contains required fields
+    if 'colorHanziTaiwan' in config['fields']:
+        target='pinyin_tw'
+        field_group='pinyinTaiwan'
+
+        field = get_first(config['fields'][field_group], note)
+        trans = sanitize_transcript(field, target, grouped=False)
+        trans = split_transcript(' '.join(trans), target, grouped=False)
+        colorized = colorize_fuse(hanzi, trans)
+        set_all(config['fields']['colorHanziTaiwan'], note, to=colorized)
+
+        if tradHanzi and 'colorTraditionalTaiwan' in config['fields']:
+            colorized = colorize_fuse(tradHanziSplit, trans)
+            set_all(config['fields']['colorTraditionalTaiwan'], note, to=colorized)
+
 
 
 def fill_sound(hanzi, note):

--- a/chinese/config.json
+++ b/chinese/config.json
@@ -137,6 +137,12 @@
             "Color Traditional",
             "Traditional (Color)"
         ],
+        "colorHanziTaiwan": [
+            "Hanzi (Taiwan Color)"
+        ],
+        "colorTraditionalTaiwan": [
+            "Traditional (Taiwan Color)"
+        ],
         "colorCantonese": [
             "ColorCant",
             "Color Cantonese",

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -391,6 +391,40 @@ class FillColor(Base):
             ),
         )
 
+    def test_taiwan_color(self):
+        note = dict.fromkeys(['Color Hanzi', 'Hanzi (Taiwan Color)', 'Traditional (Taiwan Color)'], '')
+
+        note["pinyin"] = "cōngming"
+        note["Pinyin (Taiwan)"] = "cōngmíng"
+        note["Traditional"] = "聰明"
+
+        fill_color('聪明', note)
+        
+        self.assertEqual(
+            note['Color Hanzi'],
+            (
+                '<span class="tone1">聪</span>'
+                '<span class="tone5">明</span>'
+            ),
+        )
+
+        self.assertEqual(
+            note['Hanzi (Taiwan Color)'],
+            (
+                '<span class="tone1">聪</span>'
+                '<span class="tone2">明</span>'
+            ),
+        )
+
+        self.assertEqual(
+            note['Traditional (Taiwan Color)'],
+            (
+                '<span class="tone1">聰</span>'
+                '<span class="tone2">明</span>'
+            ),
+        )
+
+
     def test_chars_no_pinyin(self):
         """Should not generate color output if no available reading."""
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -120,5 +120,7 @@ class Config(Base):
             'Traditional Measure Word',
             '繁體量詞',
             '繁体量词',
+            'Hanzi (Taiwan Color)',
+            'Traditional (Taiwan Color)'
         ]
         self.assertCountEqual(ConfigManager().get_fields(), expected)


### PR DESCRIPTION
This PR adds the fields 'colorHanziTaiwan' and 'colorTraditionalTaiwan,' which are colorized based on Taiwanese pronunciation.

Furthermore, one unit test for the new fields has been added.

Closes #59 

![grafik](https://github.com/Gustaf-C/anki-chinese-support-3/assets/19411776/f62d8650-2144-4299-9df6-56ef75f4c838)
