### PR TITLE
Fix uppercase pinyin (fixing 81)

### DIFF
--- a/chinese/color.py
+++ b/chinese/color.py
@@ -60,14 +60,16 @@ def colorize(words, target='pinyin', ruby_whole=False):
             pattern = d[target]
             text = ''
             for syllable in word.split():
-                if search(f'^{pattern}$', syllable):
-                    text += sub(f'^{pattern}$', _repl, syllable, IGNORECASE)
+                if search(f'^{pattern}$', syllable, flags=IGNORECASE):
+                    text += sub(f'^{pattern}$', _repl, syllable, flags=IGNORECASE)
                 elif has_ruby(syllable):
                     if ruby_whole:
                         pattern = RUBY_REGEX
                     else:
                         pattern = HALF_RUBY_REGEX
-                    text += sub(pattern, _repl, syllable, IGNORECASE)
+                    # For some reason HALF_RUBY_REGEX is case-insensitive per se, and RUBY_REGEX is case-sensitive
+                    # And for ruby we do not need to keep uppercase
+                    text += sub(pattern, _repl, syllable, flags=IGNORECASE).lower()
                 else:
                     text += f'<span class="tone5">{syllable}</span>'
         else:

--- a/chinese/color.py
+++ b/chinese/color.py
@@ -32,6 +32,7 @@ from .hanzi import split_hanzi
 from .sound import extract_tags
 from .transcribe import tone_number, sanitize_transcript
 from .util import align, is_punc, no_color
+from .main import config
 
 
 def colorize(words, target='pinyin', ruby_whole=False):
@@ -69,7 +70,10 @@ def colorize(words, target='pinyin', ruby_whole=False):
                         pattern = HALF_RUBY_REGEX
                     # For some reason HALF_RUBY_REGEX is case-insensitive per se, and RUBY_REGEX is case-sensitive
                     # And for ruby we do not need to keep uppercase
-                    text += sub(pattern, _repl, syllable, flags=IGNORECASE).lower()
+                    ruby = sub(pattern, _repl, syllable, flags=IGNORECASE)
+                    if config.get_config_scalar_value('lowercase_ruby'):
+                        ruby = ruby.lower()
+                    text += ruby
                 else:
                     text += f'<span class="tone5">{syllable}</span>'
         else:

--- a/chinese/config.json
+++ b/chinese/config.json
@@ -5,6 +5,7 @@
     "speech": "google|zh-CN",
     "target": "pinyin",
     "max_examples": -1,
+    "lowercase_ruby": true,
     "fields": {
         "hanzi": [
             "Chinese",

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -35,6 +35,19 @@ class TestColorize(Base):
             '<span class="tone4">xiàn</span> <span class="tone4">zài</span>',
         )
 
+    def test_uppercase(self):
+        self.assertEqual(
+            colorize(['Wǒ', 'shì']),
+            '<span class="tone3">Wǒ</span> <span class="tone4">shì</span>',
+        )
+        self.assertEqual(
+            colorize(['我[Wǒ]'], ruby_whole=True),
+            '<span class="tone3">我[wǒ]</span>',
+        )
+        self.assertEqual(
+            colorize(['我[Wǒ]']), '我[<span class="tone3">wǒ</span>]'
+        )
+
     def test_ruby(self):
         self.assertEqual(
             colorize(['你[nǐ]']), '你[<span class="tone3">nǐ</span>]'

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -65,6 +65,8 @@ class TestColorize(Base):
             mconf.get_config_scalar_value = lambda kv: \
                 chinese.config.ConfigManager.get_config_scalar_value(mconf, kv)
 
+            _lowercase_ruby = config['lowercase_ruby']
+
             config['lowercase_ruby'] = True
             self.assertEqual(
                 colorize(['你[Nǐ]']), '你[<span class="tone3">nǐ</span>]'
@@ -77,6 +79,8 @@ class TestColorize(Base):
             self.assertEqual(
                 colorize(['你[Nǐ]']), '你[<span class="tone3">Nǐ</span>]'
             )
+            # We need to restore it since test_uppercase() depends on it
+            config['lowercase_ruby'] = _lowercase_ruby
 
     def test_bopomofo(self):
         self.assertEqual(

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -18,8 +18,10 @@
 from hypothesis import given
 from hypothesis.strategies import integers
 
+import chinese.config
 from chinese.color import colorize, colorize_dict, colorize_fuse
-from tests import Base
+from tests import Base, config
+from unittest.mock import MagicMock, Mock, patch
 
 
 class TestColorize(Base):
@@ -56,6 +58,25 @@ class TestColorize(Base):
             colorize(['你[nǐ]'], ruby_whole=True),
             '<span class="tone3">你[nǐ]</span>',
         )
+
+    def test_lowercase_ruby(self):
+        with patch("chinese.color.config") as mconf:
+            mconf.config = config
+            mconf.get_config_scalar_value = lambda kv: \
+                chinese.config.ConfigManager.get_config_scalar_value(mconf, kv)
+
+            config['lowercase_ruby'] = True
+            self.assertEqual(
+                colorize(['你[Nǐ]']), '你[<span class="tone3">nǐ</span>]'
+            )
+            config['lowercase_ruby'] = False
+            self.assertEqual(
+                colorize(['你[Nǐ]']), '你[<span class="tone3">Nǐ</span>]'
+            )
+            config.pop('lowercase_ruby', None)
+            self.assertEqual(
+                colorize(['你[Nǐ]']), '你[<span class="tone3">Nǐ</span>]'
+            )
 
     def test_bopomofo(self):
         self.assertEqual(


### PR DESCRIPTION
Hopefully fix #81 

We can have pinyin with uppercase letters. So we should:
- use IGNORECASE search(), and moreother,
- explicitly name "flags=" argument in "subs", otherwise it is used for the "count" (Uh-oh) (see https://docs.python.org/3/library/re.html#re.sub)
- convert pinyin to lowercase for ruby