### PR TITLE
Update how sound is encoded on cards for compatibility with latest Anki

### DIFF
--- a/chinese/models/advanced.py
+++ b/chinese/models/advanced.py
@@ -46,8 +46,9 @@ card_back = '''\
 {{#Simplified}}<div class=chinese><span class=comment>Simplified:</span> {{Simplified}}</div>{{/Simplified}}
 {{#Traditional}}<div class=chinese><span class=comment>Traditional:</span> {{Traditional}}</div>{{/Traditional}}
 {{#Classifier}}<div class=chinese><span class=comment>Classifier:</span> {{Classifier}}</div>{{/Classifier}}
-{{#Also Written}}<div class=chinese><span class=comment>Also written:</span> {{Also Written}}</div>{{/Also Written}}<!-- {{Sound}}-->
+{{#Also Written}}<div class=chinese><span class=comment>Also written:</span> {{Also Written}}</div>{{/Also Written}}
 </div>
+<div class="chinese-support-sound">{{Sound}}</div>
 
 <div class=comment> <!-- Word lookup -->
 <a href="http://www.mdbg.net/chindict/chindict.php?page=worddict&wdrst=0&wdqb={{text:Hanzi}}">MDBG</a>,

--- a/chinese/models/basic.py
+++ b/chinese/models/basic.py
@@ -25,7 +25,7 @@ card_back = '''\
 <div>{{English}}</div>
 <div class=reading>{{Pinyin}}</div>
 <div class=chinese>{{Color}}</div>
-<!-- {{Sound}}-->
+<div class="chinese-support-sound">{{Sound}}</div>
 '''
 
 

--- a/chinese/models/css.py
+++ b/chinese/models/css.py
@@ -18,6 +18,7 @@ style = u'''\
 .note {color:gray;font-size:12pt;margin-top:20pt;}
 .hint {font-size:12pt;}
 .answer { background-color:bisque; border:dotted;border-width:1px}
+.chinese-support-sound { display: none; }
 
 .tone1 {color: red;}
 .tone2 {color: orange;}


### PR DESCRIPTION
Anki changed behaviour in a non-backwards compatible way in https://github.com/ankitects/anki/pull/3662 which took effect in the 25.02 release. This change caused the `{{Sound}}` template which was previously hidden in a comment to no longer be picked up by the parser and fed to the av subsystem.

A more correct, less janky way to achieve the same thing is by hiding the sound element in a div with `display: none` which is what I have done in this PR.

Also see https://forums.ankiweb.net/t/ankimobile-25-02-1-audio-not-playing/55920/

All existing users will find their audio stops working upon updating to 25.02. This could be possible to fix auto-fix but is a little tricky given that user might have made other modifications to their card's formatting, and we have no setting which allows a user to explicitly opt out of such changes. I guess there are a couple of ways we could handle it, but for now lets just get things patched so new users don't run into trouble.