### PR TITLE
for Cantonese use field_group = 'cantonese'

### DIFF
--- a/chinese/behavior.py
+++ b/chinese/behavior.py
@@ -210,7 +210,7 @@ def fill_color(hanzi, note):
         field_group = 'pinyin'
     elif config['target'] in 'jyutping':
         target = 'jyutping'
-        field_group = 'jyutping'
+        field_group = 'cantonese'
     else:
         raise NotImplementedError(config['target'])
 


### PR DESCRIPTION
I was trying to use Jyutping phonetics and found it crashed with the error. I think it is because there is not actually a "jyutping" field group in the config, instead it is called "cantonese"

Likely this is the bug (or one of the bugs) described in #57

```
Anki 25.02.5 (29192d15)  (ao)
Python 3.9.18 Qt 6.6.2 PyQt 6.6.1
Platform: Windows-10-10.0.26100

Traceback (most recent call last):
  File "aqt.webview", line 188, in cmd
  File "aqt.webview", line 275, in _onCmd
  File "aqt.webview", line 803, in _onBridgeCmd
  File "decorator", line 232, in fun
  File "anki.hooks", line 92, in decorator_wrapper
  File "anki.hooks", line 87, in repl
  File "aqt.editor", line 421, in onBridgeCmd
  File "_aqt.hooks", line 2548, in __call__
  File "anki.hooks", line 48, in runFilter
  File "C:\Users\Michael\AppData\Roaming\Anki2\addons21\1752008591\edit.py", line 121, in onFocusLost
    if not update_fields(note, field, allFields):
  File "C:\Users\Michael\AppData\Roaming\Anki2\addons21\1752008591\behavior.py", line 351, in update_fields
    fill_color(hanzi, copy)
  File "C:\Users\Michael\AppData\Roaming\Anki2\addons21\1752008591\behavior.py", line 218, in fill_color
    field = get_first(config['fields'][field_group], note)
KeyError: 'jyutping'
```

EDIT: Closed because it still doesn't work after this patch