### PR TITLE
Do not reformat jyutping target

### DIFF
--- a/chinese/behavior.py
+++ b/chinese/behavior.py
@@ -188,7 +188,7 @@ def fill_transcript(hanzi, note):
 
 
 def reformat_transcript(note, group, target):
-    if target == 'bopomofo':
+    if target == 'bopomofo' or target == 'jyutping':
         return
 
     transcript = get_first(config['fields'][group], note)


### PR DESCRIPTION
Fixes bug where plugin tries to accent jyutping target. This won't work and ends up trying to reformat jyutping as pinyin.