### PR TITLE
Migrate to python 3

### DIFF
--- a/chinese/lib/gtts/tests/test_tts.py
+++ b/chinese/lib/gtts/tests/test_tts.py
@@ -2,7 +2,7 @@
 import os
 import pytest
 from mock import Mock
-from six.moves import urllib
+from urllib import request as urllib_request
 
 from gtts.tts import gTTS, gTTSError
 from gtts.langs import _main_langs

--- a/chinese/lib/gtts/tts.py
+++ b/chinese/lib/gtts/tts.py
@@ -3,13 +3,10 @@ from gtts.tokenizer import pre_processors, Tokenizer, tokenizer_cases
 from gtts.utils import _minimize, _len, _clean_tokens, _translate_url
 from gtts.lang import tts_langs, _fallback_deprecated_lang
 
-from six.moves import urllib
-try:
-    from urllib.parse import quote
-    import urllib3
-except ImportError:
-    from urllib import quote
-    import urllib2
+# Python 3 imports
+from urllib.parse import quote
+from urllib import request as urllib_request
+import urllib3
 import requests
 import logging
 import json
@@ -262,7 +259,7 @@ class gTTS:
                 with requests.Session() as s:
                     # Send request
                     r = s.send(request=pr,
-                               proxies=urllib.request.getproxies(),
+                               proxies=urllib_request.getproxies(),
                                verify=False)
 
                 log.debug("headers-%i: %s", idx, r.request.headers)


### PR DESCRIPTION
Fix #123: Anki 25.9+ removed six from the default environment, so these libraries fail to import. upgrade plugin to python 3 and remove six dependency 