### PR TITLE
Fix colorization for cantonese always falling through to tone5

### DIFF
--- a/chinese/behavior.py
+++ b/chinese/behavior.py
@@ -198,7 +198,7 @@ def reformat_transcript(note, group, target):
     clean = cleanup(transcript)
     split = split_transcript(clean, target, grouped=True)
     accent = accentuate(split, target)
-    color = colorize(accent)
+    color = colorize(accent, target)
     hidden = hide(color, no_tone(color))
 
     set_all(config['fields'][group], note, to=hidden)

--- a/chinese/consts.py
+++ b/chinese/consts.py
@@ -104,7 +104,7 @@ RUBY_REGEX = r'[%s]\[\s*([a-zü%s]+[%s]?)(.*?\])' % (
 HALF_RUBY_REGEX = f'([A-Za-zü{PINYIN_VOWELS}]+[{TONE_NUMBERS}]?)'
 
 NOT_PINYIN_REGEX = (
-    f"([^A-Za-zü{BOPOMOFO_RANGE}{PINYIN_VOWELS}{CMN_TONE_NUMBERS}ˊˇˋ˙'])"
+    f"([^A-Za-zü{BOPOMOFO_RANGE}{PINYIN_VOWELS}{TONE_NUMBERS}ˊˇˋ˙'])"
 )
 
 TRANSCRIPT_REGEX_TEMPLATE = (


### PR DESCRIPTION
Previously, if target was not passed, it would default to target='pinyin', which means words will never match JYUTPING_REGEX. This meant that the span tone class will always be tone5, which is the default for pinyin/mandarin, but incorrect for Cantonese most of the time.

Before (span class always incorrect):
<img width="858" height="372" alt="image" src="https://github.com/user-attachments/assets/5ad64bfc-82c5-4d15-9091-4efef27ef700" />

After (span class correct):
<img width="850" height="363" alt="image" src="https://github.com/user-attachments/assets/ce315eac-767e-4cf1-8665-21ad79f10fe1" />


